### PR TITLE
Prevent 'receiveOneMsg' goroutine leak.

### DIFF
--- a/communicate/communicate.go
+++ b/communicate/communicate.go
@@ -225,7 +225,7 @@ func Communicate(out SendThis, quit chan struct{}) SendResult {
 		}
 	}
 
-	replyChan := make(chan receiveResult)
+	replyChan := make(chan receiveResult, 1)
 	go receiveOneMsg(cxn, out.ExpectReplyFrom, replyChan)
 
 	// socket timeout stuff

--- a/communicate/communicate.go
+++ b/communicate/communicate.go
@@ -109,7 +109,7 @@ func getRemote(in net.UDPConn) (*net.UDPAddr, error) {
 // or the socket times out. It ignores alien replies (packets not from
 // expectedSource) unless expectedSource is <nil>. It is guaranteed to
 // write to the result channel exactly once.
-func receiveOneMsg(cxn *net.UDPConn, expectedSource net.IP, result chan receiveResult) {
+func receiveOneMsg(cxn *net.UDPConn, expectedSource net.IP, result chan<- receiveResult) {
 	buffIn := make([]byte, inBufferSize)
 	var err error
 	var received int

--- a/communicate/communicate_test.go
+++ b/communicate/communicate_test.go
@@ -99,7 +99,7 @@ func TestReceive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	replyChan := make(chan receiveResult)
+	replyChan := make(chan receiveResult, 1)
 	go receiveOneMsg(listenSock, ip, replyChan)
 
 	testData := make([]byte, 25)


### PR DESCRIPTION
Per the receiveOneMsg function doc., the provided channel will be
written to at least one time. We did not buffer the provided
channel by that value. In an error scenario, this could result
in a leaked goroutine. I.e., it writes to a channel that has been
abandoned by the owner.