### PR TITLE
Fix attrcategory type

### DIFF
--- a/attribute/attr_common.go
+++ b/attribute/attr_common.go
@@ -9,7 +9,7 @@ import (
 
 type (
 	AttrType     byte
-	attrCategory string
+	attrCategory byte
 )
 
 const (

--- a/attribute/attr_common.go
+++ b/attribute/attr_common.go
@@ -162,20 +162,20 @@ func UnmarshalAttribute(b []byte) (Attribute, error) {
 	}
 
 	t := AttrType(b[0])
-	switch {
-	case attrCategoryByType[t] == duplexCategory:
+	switch attrCategoryByType[t]{
+	case duplexCategory:
 		return &duplexAttribute{attrType: t, attrData: b[2:]}, nil
-	case attrCategoryByType[t] == ipv4Category:
+	case ipv4Category:
 		return &ipv4Attribute{attrType: t, attrData: b[2:]}, nil
-	case attrCategoryByType[t] == macCategory:
+	case macCategory:
 		return &macAttribute{attrType: t, attrData: b[2:]}, nil
-	case attrCategoryByType[t] == replyStatusCategory:
+	case replyStatusCategory:
 		return &replyStatusAttribute{attrType: t, attrData: b[2:]}, nil
-	case attrCategoryByType[t] == speedCategory:
+	case speedCategory:
 		return &speedAttribute{attrType: t, attrData: b[2:]}, nil
-	case attrCategoryByType[t] == stringCategory:
+	case stringCategory:
 		return &stringAttribute{attrType: t, attrData: b[2:]}, nil
-	case attrCategoryByType[t] == vlanCategory:
+	case vlanCategory:
 		return &vlanAttribute{attrType: t, attrData: b[2:]}, nil
 	}
 


### PR DESCRIPTION
AttrCategory should never have been a string, but it "worked" up through a recent version of Go. Then: "conversion from untyped int to attrCategory (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)"